### PR TITLE
Code cleanup; enable Node builds with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "4.0"
+  - "0.12"
+  - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - "4.0"
   - "0.12"
   - "0.10"
+before_install:
+  - '[ "${TRAVIS_NODE_VERSION}" != "0.10" ] || npm install -g npm@latest'

--- a/frozen-moment.js
+++ b/frozen-moment.js
@@ -7,14 +7,8 @@
     global.moment = factory(global.moment);
   }
 }(this, function (moment) {
-  var frozenProto;
+  function FrozenMoment() {}
   var momentProto = moment.fn;
-
-  var create = Object.create || function createObject(proto) {
-    function FrozenMoment() {}
-    FrozenMoment.prototype = proto;
-    return new FrozenMoment();
-  };
 
   var includes = Array.prototype.includes || function arrayIncludes(value) {
     var length = this.length;
@@ -108,7 +102,7 @@
   }
   function freeze() {
     var props = momentProto.clone.apply(this);
-    var frozen = create(frozenProto);
+    var frozen = new FrozenMoment();
     mixin(frozen, props);
     return frozen;
   }
@@ -117,8 +111,11 @@
   }
 
   function buildFrozenPrototype() {
-    for (var key in momentProto) {
+    var MomentSubclass = function () {};
+    MomentSubclass.prototype = momentProto;
+    var frozenProto = new MomentSubclass();
 
+    for (var key in momentProto) {
       if (key === "freeze") {
         // never wrap Frozen Moment's freeze method
         continue;
@@ -133,7 +130,6 @@
         } else {
           frozenProto[key] = frozenIfArgumentsMethodGenerator(key);
         }
-
       }
     }
 
@@ -142,6 +138,8 @@
     };
     frozenProto.clone = freeze;
     frozenProto.thaw = thaw;
+
+    FrozenMoment.prototype = moment.frozen.fn = frozenProto;
   }
 
 
@@ -162,14 +160,13 @@
   moment.frozen.unwrap = function unwrapMethods(/* names... */) {
     var length = arguments.length;
     for (var i = 0, name = arguments[i]; i < length; i++) {
-      if (frozenProto[name]) {
-        delete frozenProto[name];
+      if (FrozenMoment.prototype[name]) {
+        delete FrozenMoment.prototype[name];
       }
       immutableMethods.push(name);
     }
   };
 
-  frozenProto = moment.frozen.fn = create(momentProto);
   buildFrozenPrototype();
   return moment;
 

--- a/frozen-moment.js
+++ b/frozen-moment.js
@@ -7,6 +7,10 @@
     global.moment = factory(global.moment);
   }
 }(this, function (moment) {
+  if (!moment) {
+    throw new Error('frozen-moment cannot find moment');
+  }
+
   function FrozenMoment() {}
   var momentProto = moment.fn;
 


### PR DESCRIPTION
Use prototypes and constructors to avoid Object.create, so that we have the same object creation code in all supported browsers (rather than shimming IE 8).

Also use Travis to run the tests in multiple popular versions of Node, and throw a more explicit error when we can't find the `moment` object during initialization.
